### PR TITLE
Implement IPFS upload for batch creation

### DIFF
--- a/src/app/api/ipfs/file/route.ts
+++ b/src/app/api/ipfs/file/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'File missing' }, { status: 400 });
+  }
+
+  const pinataData = new FormData();
+  pinataData.set('file', file);
+
+  const res = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.PINATA_JWT}`,
+    },
+    body: pinataData,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('Pinata file upload failed', text);
+    return NextResponse.json({ error: 'Pinata upload failed' }, { status: 500 });
+  }
+
+  const json = await res.json();
+  return NextResponse.json({ cid: json.IpfsHash });
+}

--- a/src/app/api/ipfs/json/route.ts
+++ b/src/app/api/ipfs/json/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  const res = await fetch('https://api.pinata.cloud/pinning/pinJSONToIPFS', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.PINATA_JWT}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('Pinata JSON upload failed', text);
+    return NextResponse.json({ error: 'Pinata upload failed' }, { status: 500 });
+  }
+
+  const json = await res.json();
+  return NextResponse.json({ cid: json.IpfsHash });
+}


### PR DESCRIPTION
## Summary
- add Next.js API routes for uploading files and JSON to Pinata IPFS
- integrate photo and metadata upload in `CreateBatchModal`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5b197f8c83319634302b36969d30