### PR TITLE
Add role onboarding and switching

### DIFF
--- a/src/app/api/user/connect/route.ts
+++ b/src/app/api/user/connect/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { address, role } = await request.json();
+    if (!address || !role) {
+      return NextResponse.json({ error: 'Address and role required' }, { status: 400 });
+    }
+    const wallet = (address as string).toLowerCase();
+    switch (role) {
+      case 'FARMER':
+        await prisma.farmer.upsert({
+          where: { walletAddress: wallet },
+          update: {},
+          create: { walletAddress: wallet },
+        });
+        break;
+      case 'BUYER':
+        await prisma.buyer.upsert({
+          where: { walletAddress: wallet },
+          update: {},
+          create: { walletAddress: wallet },
+        });
+        break;
+      case 'TRANSPORTER':
+        await prisma.transporter.upsert({
+          where: { walletAddress: wallet },
+          update: {},
+          create: { walletAddress: wallet },
+        });
+        break;
+      default:
+        return NextResponse.json({ error: 'Invalid role' }, { status: 400 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Failed to connect user', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/buyer/page.tsx
+++ b/src/app/buyer/page.tsx
@@ -8,8 +8,10 @@ import { Input } from '@/components/ui/input';
 import { BottomNav } from '@/components/ui/bottom-nav';
 import { useState, useEffect } from 'react';
 import { CommitModal } from '@/components/buyer/commit-modal';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
 
 export default function BuyerDashboard() {
+  useRequireRole('BUYER');
   const [showCommitModal, setShowCommitModal] = useState(false);
   const [selectedBatch, setSelectedBatch] = useState<any>(null);
   const [availableBatches, setAvailableBatches] = useState<any[]>([]);

--- a/src/app/farmer/page.tsx
+++ b/src/app/farmer/page.tsx
@@ -10,8 +10,10 @@ import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { useAccount } from 'wagmi';
 import { CreateBatchModal } from '@/components/farmer/create-batch-modal';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
 
 export default function FarmerDashboard() {
+  useRequireRole('FARMER');
   const { address } = useAccount();
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [stats, setStats] = useState<{

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { Toaster } from "react-hot-toast";
+import { RoleSwitcher } from '@/components/role-switcher';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -59,6 +60,7 @@ export default function RootLayout({
               },
             }}
           />
+          <RoleSwitcher />
         </Providers>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,22 +3,33 @@
 import { motion } from 'framer-motion';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { useAccount } from 'wagmi';
-import { useRole } from '@/lib/hooks/useRole';
+import { useRole, Role } from '@/lib/hooks/useRole';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Wheat, Shield, Truck, Users } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 export default function Home() {
-  const { isConnected } = useAccount();
+  const { address, isConnected } = useAccount();
   const { role, loading } = useRole();
+  const [selectedRole, setSelectedRole] = useState<Role>('FARMER');
   const router = useRouter();
 
   useEffect(() => {
-    if (isConnected && role && !loading) {
-      router.push(`/${role.toLowerCase()}`);
+    async function register() {
+      if (isConnected && address && selectedRole && !role && !loading) {
+        await fetch('/api/user/connect', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ address, role: selectedRole }),
+        });
+        router.push(`/${selectedRole.toLowerCase()}`);
+      } else if (isConnected && role && !loading) {
+        router.push(`/${role.toLowerCase()}`);
+      }
     }
-  }, [isConnected, role, loading, router]);
+    register();
+  }, [isConnected, address, role, loading, selectedRole, router]);
 
   const features = [
     {
@@ -86,6 +97,18 @@ export default function Home() {
             transition={{ delay: 0.3, duration: 0.4 }}
             className="mb-12"
           >
+            <div className="flex justify-center gap-3 mb-6">
+              {(['FARMER', 'BUYER', 'TRANSPORTER'] as Role[]).map((r) => (
+                <Button
+                  key={r}
+                  variant={selectedRole === r ? 'primary' : 'outline'}
+                  size="sm"
+                  onClick={() => setSelectedRole(r)}
+                >
+                  {r.charAt(0) + r.slice(1).toLowerCase()}
+                </Button>
+              ))}
+            </div>
             <ConnectButton.Custom>
               {({
                 account,

--- a/src/app/transporter/page.tsx
+++ b/src/app/transporter/page.tsx
@@ -8,8 +8,10 @@ import { BottomNav } from '@/components/ui/bottom-nav';
 import { useState, useEffect } from 'react';
 import { useAccount } from 'wagmi';
 import { QRScanModal } from '@/components/transporter/qr-scan-modal';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
 
 export default function TransporterDashboard() {
+  useRequireRole('TRANSPORTER');
   const { address } = useAccount();
   const [showScanModal, setShowScanModal] = useState(false);
   const [activeDeliveries, setActiveDeliveries] = useState<any[]>([]);

--- a/src/components/role-switcher.tsx
+++ b/src/components/role-switcher.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { useAccount } from 'wagmi';
+import { useRouter } from 'next/navigation';
+import { Role, useRole } from '@/lib/hooks/useRole';
+import { Modal } from '@/components/ui/modal';
+import { Button } from '@/components/ui/button';
+
+export function RoleSwitcher() {
+  const [open, setOpen] = useState(false);
+  const { address } = useAccount();
+  const { role } = useRole();
+  const router = useRouter();
+
+  const switchRole = async (r: Role) => {
+    if (!address || !r) return;
+    await fetch('/api/user/connect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address, role: r }),
+    });
+    setOpen(false);
+    router.push(`/${r.toLowerCase()}`);
+  };
+
+  if (!address) return null;
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 bg-ocean-navy text-warm-white p-3 rounded-full shadow-lg z-50"
+      >
+        Switch Role
+      </button>
+      <Modal isOpen={open} onClose={() => setOpen(false)} title="Switch Role">
+        <div className="space-y-3">
+          {(['FARMER', 'BUYER', 'TRANSPORTER'] as Role[]).map((r) => (
+            <Button
+              key={r}
+              variant={role === r ? 'secondary' : 'primary'}
+              onClick={() => switchRole(r)}
+              className="w-full"
+            >
+              {r.charAt(0) + r.slice(1).toLowerCase()}
+            </Button>
+          ))}
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/lib/hooks/useRequireRole.ts
+++ b/src/lib/hooks/useRequireRole.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { Role, useRole } from './useRole';
+
+export function useRequireRole(required: Role) {
+  const { role, loading } = useRole();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading) {
+      if (role !== required) {
+        router.push('/');
+      }
+    }
+  }, [role, required, loading, router]);
+
+  return { role, loading };
+}


### PR DESCRIPTION
## Summary
- create endpoint to register wallet with a role
- read roles from Prisma instead of mock data
- add role selection on the landing page
- enforce role based access on role pages
- global floating role switcher for demo

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db3741c50833183a134e7540154ef