### PR TITLE
Fix Link href warning in farmer dashboard

### DIFF
--- a/src/app/farmer/page.tsx
+++ b/src/app/farmer/page.tsx
@@ -34,9 +34,27 @@ export default function FarmerDashboard() {
         setRecentBatches(batches);
         const active = batches.filter((b: any) => b.status !== 'DELIVERED' && b.status !== 'FINALISED').length;
         setStats([
-          { label: 'Active Batches', value: String(active), icon: Package, color: 'text-teal-deep' },
-          { label: 'Total Revenue', value: '$0', icon: TrendingUp, color: 'text-aqua-mint' },
-          { label: 'Pending Deals', value: '0', icon: Clock, color: 'text-orange-500' },
+          {
+            label: 'Active Batches',
+            value: String(active),
+            icon: Package,
+            color: 'text-teal-deep',
+            href: '/farmer/batches',
+          },
+          {
+            label: 'Total Revenue',
+            value: '$0',
+            icon: TrendingUp,
+            color: 'text-aqua-mint',
+            href: '/farmer/revenue',
+          },
+          {
+            label: 'Pending Deals',
+            value: '0',
+            icon: Clock,
+            color: 'text-orange-500',
+            href: '/farmer/deals',
+          },
         ]);
       } catch (err) {
         console.error('Failed loading farmer data', err);


### PR DESCRIPTION
## Summary
- set URL links for farmer dashboard stat cards

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db73f8c00833188e3dc51fed3f0ea