### PR TITLE
Enable batch origin capture

### DIFF
--- a/prisma/migrations/20250626213040_add_batch_location/migration.sql
+++ b/prisma/migrations/20250626213040_add_batch_location/migration.sql
@@ -1,0 +1,3 @@
+-- Add location columns to Batch
+ALTER TABLE "Batch" ADD COLUMN "locationLat" DOUBLE PRECISION;
+ALTER TABLE "Batch" ADD COLUMN "locationLng" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,8 @@ model Batch {
   metaCid        String
   photoCid       String
   origin         String?
+  locationLat    Float?
+  locationLng    Float?
   destination    String?
   grade          String?
   weightKg       Float

--- a/src/app/api/batch/route.ts
+++ b/src/app/api/batch/route.ts
@@ -65,6 +65,8 @@ export async function POST(req: NextRequest) {
         metaCid: body.metaCid,
         photoCid: body.photoCid,
         origin: body.origin,
+        locationLat: body.locationLat,
+        locationLng: body.locationLng,
         grade: body.grade,
         weightKg: body.weightKg,
         farmerId: farmer.id,

--- a/src/app/buyer/page.tsx
+++ b/src/app/buyer/page.tsx
@@ -87,6 +87,11 @@ export default function BuyerDashboard() {
                             <MapPin size={14} />
                             {batch.origin}
                           </div>
+                          {batch.locationLat && (
+                            <div className="text-xs text-dusk-gray">
+                              {batch.locationLat.toFixed(5)}, {batch.locationLng.toFixed(5)}
+                            </div>
+                          )}
                         </div>
                         <div className="flex items-center gap-1">
                           <Star size={14} className="text-yellow-500 fill-current" />

--- a/src/app/farmer/batches/page.tsx
+++ b/src/app/farmer/batches/page.tsx
@@ -52,6 +52,11 @@ export default function FarmerBatchesPage() {
                       <MapPin size={14} />
                       {batch.origin}
                     </div>
+                    {batch.locationLat && (
+                      <div className="text-xs text-dusk-gray mt-1">
+                        {batch.locationLat.toFixed(5)}, {batch.locationLng.toFixed(5)}
+                      </div>
+                    )}
                   </div>
                   <div className="text-right">
                     <div

--- a/src/app/transporter/page.tsx
+++ b/src/app/transporter/page.tsx
@@ -114,6 +114,9 @@ export default function TransporterDashboard() {
                       <MapPin size={14} className="text-teal-deep" />
                       <span className="text-dusk-gray">Pickup:</span>
                       <span className="text-ocean-navy">{delivery.batch?.origin}</span>
+                      {delivery.batch?.locationLat && (
+                        <span className="text-xs text-dusk-gray"> ({delivery.batch.locationLat.toFixed(5)}, {delivery.batch.locationLng.toFixed(5)})</span>
+                      )}
                     </div>
                     <div className="flex items-center gap-2 text-sm">
                       <MapPin size={14} className="text-aqua-mint" />

--- a/src/components/farmer/create-batch-modal.tsx
+++ b/src/components/farmer/create-batch-modal.tsx
@@ -22,6 +22,8 @@ export function CreateBatchModal({ isOpen, onClose }: CreateBatchModalProps) {
     weight: '',
     grade: '1',
     origin: '',
+    latitude: '',
+    longitude: '',
     photo: null as File | null,
   });
   const [step, setStep] = useState<'form' | 'minting' | 'success'>('form');
@@ -37,7 +39,13 @@ export function CreateBatchModal({ isOpen, onClose }: CreateBatchModalProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!formData.weight || !formData.photo || !formData.origin) {
+    if (
+      !formData.weight ||
+      !formData.photo ||
+      !formData.origin ||
+      !formData.latitude ||
+      !formData.longitude
+    ) {
       toast.error('Please fill all fields and upload a photo');
       return;
     }
@@ -59,6 +67,11 @@ export function CreateBatchModal({ isOpen, onClose }: CreateBatchModalProps) {
       const meta = {
         weightKg: parseFloat(formData.weight),
         grade: parseInt(formData.grade),
+        origin: formData.origin,
+        location: {
+          lat: parseFloat(formData.latitude),
+          lng: parseFloat(formData.longitude),
+        },
         image: `ipfs://${photoCID}`,
       };
       const metaRes = await fetch('/api/ipfs/json', {
@@ -97,7 +110,7 @@ export function CreateBatchModal({ isOpen, onClose }: CreateBatchModalProps) {
 
   const handleClose = () => {
     setStep('form');
-    setFormData({ weight: '', grade: '1', origin: '', photo: null });
+    setFormData({ weight: '', grade: '1', origin: '', latitude: '', longitude: '', photo: null });
     setTokenId('');
     onClose();
   };
@@ -135,6 +148,8 @@ export function CreateBatchModal({ isOpen, onClose }: CreateBatchModalProps) {
             grade: formData.grade,
             weightKg: parseFloat(formData.weight),
             origin: formData.origin,
+            locationLat: parseFloat(formData.latitude),
+            locationLng: parseFloat(formData.longitude),
             farmerAddress: address,
           }),
         });
@@ -173,6 +188,43 @@ export function CreateBatchModal({ isOpen, onClose }: CreateBatchModalProps) {
             placeholder="e.g. Kampala Warehouse"
             required
           />
+
+          <div className="grid grid-cols-2 gap-4">
+            <Input
+              label="Latitude"
+              type="number"
+              step="0.000001"
+              value={formData.latitude}
+              onChange={(e) => setFormData(prev => ({ ...prev, latitude: e.target.value }))}
+              placeholder="0.000000"
+              required
+            />
+            <Input
+              label="Longitude"
+              type="number"
+              step="0.000001"
+              value={formData.longitude}
+              onChange={(e) => setFormData(prev => ({ ...prev, longitude: e.target.value }))}
+              placeholder="0.000000"
+              required
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              navigator.geolocation.getCurrentPosition((pos) => {
+                const { latitude, longitude } = pos.coords;
+                setFormData((prev) => ({
+                  ...prev,
+                  latitude: latitude.toString(),
+                  longitude: longitude.toString(),
+                }));
+              });
+            }}
+          >
+            Use Current Location
+          </Button>
 
           <div className="space-y-2">
             <label className="block text-sm font-medium text-ocean-navy">


### PR DESCRIPTION
## Summary
- store `origin` when creating batches
- display each batch with origin on farmer batches page
- add origin field to create batch form

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db9175a4483318f6f8742980e7be5