### PR TITLE
Add profile pages with logout option

### DIFF
--- a/src/app/buyer/profile/page.tsx
+++ b/src/app/buyer/profile/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { BottomNav } from '@/components/ui/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
+import { useAccount, useDisconnect } from 'wagmi';
+
+export default function BuyerProfilePage() {
+  useRequireRole('BUYER');
+  const { address } = useAccount();
+  const { disconnect } = useDisconnect();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-warm-white to-lime-lush/5 pb-20">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-3xl font-bold text-ocean-navy">Profile</h1>
+        <p className="text-dusk-gray break-all">Address: {address}</p>
+        <Button variant="outline" onClick={() => disconnect()}>Logout</Button>
+      </div>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/farmer/profile/page.tsx
+++ b/src/app/farmer/profile/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { BottomNav } from '@/components/ui/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
+import { useAccount, useDisconnect } from 'wagmi';
+
+export default function FarmerProfilePage() {
+  useRequireRole('FARMER');
+  const { address } = useAccount();
+  const { disconnect } = useDisconnect();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-warm-white to-lime-lush/5 pb-20">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-3xl font-bold text-ocean-navy">Profile</h1>
+        <p className="text-dusk-gray break-all">Address: {address}</p>
+        <Button variant="outline" onClick={() => disconnect()}>Logout</Button>
+      </div>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/transporter/profile/page.tsx
+++ b/src/app/transporter/profile/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { BottomNav } from '@/components/ui/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
+import { useAccount, useDisconnect } from 'wagmi';
+
+export default function TransporterProfilePage() {
+  useRequireRole('TRANSPORTER');
+  const { address } = useAccount();
+  const { disconnect } = useDisconnect();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-warm-white to-lime-lush/5 pb-20">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-3xl font-bold text-ocean-navy">Profile</h1>
+        <p className="text-dusk-gray break-all">Address: {address}</p>
+        <Button variant="outline" onClick={() => disconnect()}>Logout</Button>
+      </div>
+      <BottomNav />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple profile pages for farmer, buyer, and transporter
- include logout button that disconnects the wallet

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb041110833186dd5377b59db02b