### PR TITLE
Add location-based freight calculation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ DIESEL_PRICE_API_KEY=your_api_key
 # NextAuth (if using authentication)
 NEXTAUTH_SECRET="33+1+UcToPBHF4TtuRMySn5+eUQc+DtAjIC4tsIaIQ0="
 NEXTAUTH_URL=http://localhost:3000
+
+# Google Maps
+GOOGLE_MAPS_API_KEY=your_google_maps_api_key

--- a/src/app/api/distance/route.ts
+++ b/src/app/api/distance/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+function toRad(value: number) {
+  return (value * Math.PI) / 180;
+}
+
+function haversine(lat1: number, lon1: number, lat2: number, lon2: number) {
+  const R = 6371; // Earth radius in km
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const batchId = searchParams.get('batchId');
+  const latStr = searchParams.get('lat');
+  const lngStr = searchParams.get('lng');
+
+  if (!batchId || !latStr || !lngStr) {
+    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });
+  }
+
+  const lat = parseFloat(latStr);
+  const lng = parseFloat(lngStr);
+  if (Number.isNaN(lat) || Number.isNaN(lng)) {
+    return NextResponse.json({ error: 'Invalid coordinates' }, { status: 400 });
+  }
+
+  const batch = await prisma.batch.findUnique({ where: { id: batchId } });
+  if (!batch || batch.locationLat === null || batch.locationLng === null) {
+    return NextResponse.json({ error: 'Batch location not found' }, { status: 404 });
+  }
+
+  const distance = haversine(lat, lng, batch.locationLat, batch.locationLng);
+  return NextResponse.json({ distance });
+}

--- a/src/app/api/places/route.ts
+++ b/src/app/api/places/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const input = searchParams.get('input');
+  const placeId = searchParams.get('placeId');
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Missing Google Maps API key' }, { status: 500 });
+  }
+
+  try {
+    if (placeId) {
+      const res = await fetch(
+        `https://maps.googleapis.com/maps/api/place/details/json?place_id=${placeId}&key=${apiKey}`
+      );
+      const data = await res.json();
+      return NextResponse.json(data);
+    }
+
+    if (input) {
+      const res = await fetch(
+        `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(
+          input
+        )}&key=${apiKey}`
+      );
+      const data = await res.json();
+      return NextResponse.json(data);
+    }
+
+    return NextResponse.json({ predictions: [] });
+  } catch (err) {
+    console.error('Places API error', err);
+    return NextResponse.json({ error: 'Places API error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add Google Places and distance API routes
- update buyer commit modal with location input & geolocation support
- add GOOGLE_MAPS_API_KEY to env example

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbe49931083319988b4219b293487