### PR TITLE
Enable platform diesel price update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - **Farmers**: List batches, track receipts
 - **Transporters**: Scan QR codes, manage deliveries
 - **Buyers**: Browse market, commit payments
-- **Platform**: Finalize deals, resolve disputes
+- **Platform**: Finalize deals, resolve disputes, update diesel prices
 
 ### Smart Contract Integration
 - **EscrowSafe v3**: Secure payment handling

--- a/src/app/api/user/connect/route.ts
+++ b/src/app/api/user/connect/route.ts
@@ -30,6 +30,13 @@ export async function POST(request: NextRequest) {
         case 'TRANSPORTER':
           await tx.transporter.create({ data: { walletAddress: wallet } });
           break;
+        case 'PLATFORM':
+          await tx.platform.upsert({
+            where: { id: 1 },
+            update: { walletAddress: wallet },
+            create: { id: 1, walletAddress: wallet },
+          });
+          break;
         default:
           throw new Error('Invalid role');
       }

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { BottomNav } from '@/components/ui/bottom-nav';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
+
+export default function PlatformDashboard() {
+  useRequireRole('PLATFORM');
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-warm-white to-lime-lush/5 pb-20">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold text-ocean-navy mb-2">Platform Dashboard</h1>
+        <p className="text-dusk-gray">Manage deals and platform settings</p>
+      </div>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/platform/settings/page.tsx
+++ b/src/app/platform/settings/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { BottomNav } from '@/components/ui/bottom-nav';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useRequireRole } from '@/lib/hooks/useRequireRole';
+import { useWriteContract, useReadContract } from 'wagmi';
+import { CONTRACTS, ORACLE_ABI } from '@/lib/contracts';
+import toast from 'react-hot-toast';
+
+export default function PlatformSettingsPage() {
+  useRequireRole('PLATFORM');
+  const [price, setPrice] = useState('');
+  const { data: currentPrice, refetch } = useReadContract({
+    address: CONTRACTS.ORACLE as `0x${string}`,
+    abi: ORACLE_ABI,
+    functionName: 'dieselUgxPerLitre',
+  });
+  const { writeContract, isPending } = useWriteContract();
+
+  const handleUpdate = () => {
+    const val = parseFloat(price);
+    if (isNaN(val) || val <= 0) {
+      toast.error('Enter a valid price');
+      return;
+    }
+    writeContract({
+      address: CONTRACTS.ORACLE as `0x${string}`,
+      abi: ORACLE_ABI,
+      functionName: 'update',
+      args: [BigInt(Math.floor(val))],
+    });
+    toast.success('Update transaction sent');
+    setTimeout(() => refetch(), 2000);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-warm-white to-lime-lush/5 pb-20">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-3xl font-bold text-ocean-navy">Settings</h1>
+        {currentPrice && (
+          <p className="text-dusk-gray">Current price: UGX {Number(currentPrice).toLocaleString()}</p>
+        )}
+        <Input
+          label="Diesel price (UGX/litre)"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          placeholder="5000"
+        />
+        <Button onClick={handleUpdate} loading={isPending}>Update Diesel Price</Button>
+      </div>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/components/role-switcher.tsx
+++ b/src/components/role-switcher.tsx
@@ -49,10 +49,16 @@ export function RoleSwitcher() {
 
   const getRoleIcon = (r: Role) => {
     switch (r) {
-      case 'FARMER': return '🌾';
-      case 'BUYER': return '🛒';
-      case 'TRANSPORTER': return '🚛';
-      default: return '👤';
+      case 'FARMER':
+        return '🌾';
+      case 'BUYER':
+        return '🛒';
+      case 'TRANSPORTER':
+        return '🚛';
+      case 'PLATFORM':
+        return '⚙️';
+      default:
+        return '👤';
     }
   };
 
@@ -74,7 +80,7 @@ export function RoleSwitcher() {
           <p className="text-sm text-dusk-gray mb-4">
             Choose the role you want to act as. You can switch between roles anytime.
           </p>
-          {(['FARMER', 'BUYER', 'TRANSPORTER'] as Role[]).map((r) => (
+          {(['FARMER', 'BUYER', 'TRANSPORTER', 'PLATFORM'] as Role[]).map((r) => (
             <Button
               key={r}
               variant={role === r ? 'secondary' : 'primary'}


### PR DESCRIPTION
## Summary
- allow connecting as Platform role
- display Platform role option in role switcher
- create Platform dashboard and settings pages
- implement diesel price updater in settings
- document diesel price feature in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd7f1f0b483319b18a35a138da69e