### PR TITLE
Implement driver acceptance flow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,8 @@ enum BatchStatus {
 }
 
 enum DealStatus {
+  PENDING_DRIVER  // awaiting transporter to accept
+  AWAITING_ESCROW // transporter accepted, waiting buyer lock
   PENDING_SIGS    // waiting for all 3 operational sigs
   READY_TO_FINAL  // all sigs present, platform pending
   PAID_OUT
@@ -116,13 +118,13 @@ model Deal {
   batch           Batch       @relation(fields: [batchId], references: [id])
 
   farmerAmount    Decimal @db.Decimal(38, 18)
-  freightAmount   Decimal @db.Decimal(38, 18)
-  platformFee     Decimal @db.Decimal(38, 18)
-  totalLocked     Decimal @db.Decimal(38, 18)
+  freightAmount   Decimal? @db.Decimal(38, 18)
+  platformFee     Decimal? @db.Decimal(38, 18)
+  totalLocked     Decimal? @db.Decimal(38, 18)
 
   sigMask         Int
   platformAck     Boolean     @default(false)
-  status          DealStatus  @default(PENDING_SIGS)
+  status          DealStatus  @default(PENDING_DRIVER)
   
   // Timeout for signatures (in hours, default 24 hours)
   signatureTimeoutHours Int     @default(24)
@@ -137,8 +139,8 @@ model Deal {
   buyerId         String
   buyer           Buyer        @relation("BuyerDeals", fields: [buyerId], references: [id])
 
-  transporterId   String
-  transporter     Transporter  @relation("TransporterDeals", fields: [transporterId], references: [id])
+  transporterId   String?
+  transporter     Transporter? @relation("TransporterDeals", fields: [transporterId], references: [id])
 
   platformId      Int          @default(1)
   platform        Platform     @relation(fields: [platformId], references: [id])

--- a/src/app/api/deal/accept/route.ts
+++ b/src/app/api/deal/accept/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function POST(req: NextRequest) {
+  try {
+    const {
+      dealId,
+      transporterAddress,
+      freightAmount,
+      platformFee,
+      totalLocked,
+    } = await req.json();
+
+    const transporterWallet = transporterAddress.toLowerCase();
+
+    const transporter = await prisma.transporter.findUnique({
+      where: { walletAddress: transporterWallet },
+    });
+    if (!transporter) {
+      return NextResponse.json({ error: 'Transporter not found' }, { status: 400 });
+    }
+
+    const deal = await prisma.deal.update({
+      where: { id: dealId },
+      data: {
+        transporterId: transporter.id,
+        freightAmount,
+        platformFee,
+        totalLocked,
+        status: 'AWAITING_ESCROW',
+      },
+      include: {
+        batch: true,
+        buyer: true,
+        transporter: true,
+        signatures: true,
+      },
+    });
+
+    return NextResponse.json(deal);
+  } catch (error) {
+    console.error('Driver accept failed:', error);
+    return NextResponse.json({ error: 'Driver accept failed' }, { status: 500 });
+  }
+}

--- a/src/app/transporter/page.tsx
+++ b/src/app/transporter/page.tsx
@@ -129,12 +129,18 @@ export default function TransporterDashboard() {
                     <span className={`text-sm px-3 py-1 rounded-full ${
                       delivery.status === 'PENDING_SIGS'
                         ? 'bg-lime-lush/20 text-lime-700'
+                        : delivery.status === 'AWAITING_ESCROW'
+                        ? 'bg-yellow-100 text-yellow-700'
                         : 'bg-aqua-mint/20 text-aqua-mint'
                     }`}>
                       {delivery.status}
                     </span>
                     <Button size="sm" variant="outline">
-                      {delivery.status === 'PENDING_SIGS' ? 'Sign Pickup' : 'Track'}
+                      {delivery.status === 'PENDING_SIGS'
+                        ? 'Sign Pickup'
+                        : delivery.status === 'AWAITING_ESCROW'
+                        ? 'Awaiting Buyer'
+                        : 'Track'}
                     </Button>
                   </div>
                 </motion.div>


### PR DESCRIPTION
## Summary
- extend `DealStatus` with driver workflow states
- make transporter and amounts optional in `Deal`
- store deals before transporter accepts
- add endpoint for transporter acceptance
- update buyer commit modal to create pending deals
- show `AWAITING_ESCROW` status on transporter page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de2d3766c83319e2a3c53d55fe8d6