### PR TITLE
Update batch state on deal events

### DIFF
--- a/src/app/api/deal/[dealId]/accept/route.ts
+++ b/src/app/api/deal/[dealId]/accept/route.ts
@@ -67,6 +67,12 @@ export async function POST(
       },
     });
 
+    // Assign transporter to the batch as well
+    await prisma.batch.update({
+      where: { id: updatedDeal.batchId },
+      data: { transporterId: transporter.id },
+    });
+
     return NextResponse.json(updatedDeal);
   } catch (error) {
     console.error('Error accepting deal:', error);

--- a/src/app/api/deal/accept/route.ts
+++ b/src/app/api/deal/accept/route.ts
@@ -37,6 +37,12 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    // Attach transporter to the batch record as well
+    await prisma.batch.update({
+      where: { id: deal.batchId },
+      data: { transporterId: transporter.id },
+    });
+
     return NextResponse.json(deal);
   } catch (error) {
     console.error('Driver accept failed:', error);

--- a/src/app/api/deal/route.ts
+++ b/src/app/api/deal/route.ts
@@ -141,6 +141,12 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    // Mark the batch as locked once a buyer commits
+    await prisma.batch.update({
+      where: { id: batchId },
+      data: { status: 'LOCKED' },
+    });
+
     return NextResponse.json(deal);
   } catch (error) {
     console.error('Deal creation failed:', error);


### PR DESCRIPTION
## Summary
- update `/api/deal` so a batch moves to `LOCKED` when a buyer commits
- when a driver accepts a deal, attach the transporter to the batch
- keep non-parameter and parameter accept routes in sync

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0887531c8331bb35277db55dcfaa