### PR TITLE
Fix context typing for escrow route

### DIFF
--- a/src/app/api/deal/[dealId]/escrow/route.ts
+++ b/src/app/api/deal/[dealId]/escrow/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
+interface Context {
+  params: {
+    dealId: string;
+  };
+}
+
 export async function POST(
   request: NextRequest,
-  { params }: { params: { dealId: string } }
+  context: Context,
 ) {
+  const { params } = context;
   try {
     const { escrowTxHash } = await request.json();
     const { dealId } = params;


### PR DESCRIPTION
## Summary
- correct context parameter usage in escrow payment API route

## Testing
- `yarn install` *(fails: Bad response 403)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5f017ac833186940a7aae7e47b3