### PR TITLE
Fix dynamic route function signature

### DIFF
--- a/src/app/api/deal/[dealId]/escrow/route.ts
+++ b/src/app/api/deal/[dealId]/escrow/route.ts
@@ -1,17 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
-interface Context {
-  params: {
-    dealId: string;
-  };
-}
-
 export async function POST(
   request: NextRequest,
-  context: Context,
+  { params }: { params: { dealId: string } },
 ) {
-  const { params } = context;
   try {
     const { escrowTxHash } = await request.json();
     const { dealId } = params;


### PR DESCRIPTION
## Summary
- correct POST signature in escrow API route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee9d2c4c08331b569d590014e37b9