### PR TITLE
Fix POST export in escrow API route

### DIFF
--- a/src/app/api/deal/[dealId]/escrow/route.ts
+++ b/src/app/api/deal/[dealId]/escrow/route.ts
@@ -3,7 +3,7 @@ import prisma from '@/lib/prisma';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { dealId: string } },
+  { params }: { params: { dealId: string } }
 ) {
   try {
     const { escrowTxHash } = await request.json();


### PR DESCRIPTION
## Summary
- remove trailing comma from POST function signature so Next.js recognizes the handler

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685eed75d9308331ba311072ff9c81f6