### PR TITLE
Fix dynamic API routes for Vercel

### DIFF
--- a/src/app/api/deal/[dealId]/accept/route.ts
+++ b/src/app/api/deal/[dealId]/accept/route.ts
@@ -3,6 +3,7 @@ import prisma from '@/lib/prisma';
 
 // Force dynamic rendering
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ dealId: string }> }) {
   console.log('=== DEAL ACCEPT GET CALLED ===');

--- a/src/app/api/deal/[dealId]/escrow/route.ts
+++ b/src/app/api/deal/[dealId]/escrow/route.ts
@@ -3,6 +3,7 @@ import prisma from '@/lib/prisma';
 
 // Force dynamic rendering
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ dealId: string }> }) {
   try {

--- a/src/app/api/deal/[dealId]/farmer-sign/route.ts
+++ b/src/app/api/deal/[dealId]/farmer-sign/route.ts
@@ -6,6 +6,7 @@ const FARMER_BIT = 0x2;
 
 // Force dynamic rendering
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ dealId: string }> }) {
   try {

--- a/src/app/api/deal/[dealId]/finalize/route.ts
+++ b/src/app/api/deal/[dealId]/finalize/route.ts
@@ -3,6 +3,7 @@ import prisma from '@/lib/prisma';
 
 // Force dynamic rendering
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ dealId: string }> }) {
   try {

--- a/src/app/api/deal/[dealId]/transporter-sign/route.ts
+++ b/src/app/api/deal/[dealId]/transporter-sign/route.ts
@@ -8,6 +8,7 @@ const BUYER_BIT = 0x1;
 
 // Force dynamic rendering
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ dealId: string }> }) {
   try {


### PR DESCRIPTION
## Summary
- ensure dynamic deal routes run on the Node.js runtime

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbedecf308331814a1a9ab9f9100d